### PR TITLE
Fix #3: プルリクからmainにマージしたときにパッチをmake patchをしたい

### DIFF
--- a/.github/workflows/auto-patch.yml
+++ b/.github/workflows/auto-patch.yml
@@ -1,0 +1,29 @@
+name: Auto Patch Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  auto-patch:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Configure git
+      run: |
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+    - name: Run make patch
+      run: |
+        chmod +x scripts/bump-version.sh
+        make patch


### PR DESCRIPTION
## Summary
- Added GitHub Actions workflow to automatically run `make patch` when a pull request is merged into the main branch
- This creates automatic patch version releases whenever new features or fixes are merged

## Changes
1. **New workflow**: `.github/workflows/auto-patch.yml`
   - Triggers on PR merge to main branch
   - Runs `make patch` to bump patch version and create git tag
   - Uses GitHub Actions bot for git operations
   - Has proper permissions to write to repository

## How it works
1. When a PR is merged to main → auto-patch workflow runs
2. `make patch` bumps version (e.g., v1.0.0 → v1.0.1) and creates tag
3. New tag triggers existing build.yml and release.yml workflows
4. Automatic release is created with binaries

## Test plan
- [x] Verify workflow syntax is correct
- [x] Check that permissions are properly configured
- [x] Ensure git configuration is set for GitHub Actions bot
- [ ] Test by merging this PR (will trigger the workflow for the first time)

Closes #3

🤖 Generated with [Claude Code](https://claude.ai/code)