### PR TITLE
Fix #5: updateコマンドを入力した後もupdateしろと言われる

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"runtime"
 
+	"github.com/MRyutaro/rrk/internal/updater"
 	"github.com/spf13/cobra"
 )
 
@@ -110,6 +111,9 @@ func updateRrk() error {
 
 	fmt.Println("✅ rrk has been successfully updated!")
 	fmt.Printf("Updated binary location: %s\n", execPath)
+
+	// Clear version cache to avoid showing update messages for the new version
+	updater.ClearCache()
 
 	// Show new version
 	versionCmd := exec.Command(execPath, "--version")


### PR DESCRIPTION
## Summary
Fixed the issue where `rrk update` would continue showing update notifications even after successfully updating to the latest version.

## Root Cause Analysis
1. **Incorrect version comparison**: Simple string comparison didn't handle semantic versioning properly
2. **Backwards logic**: The issue showed "0.0.13 available (current: 0.0.15)" because older versions were being treated as newer
3. **Persistent cache**: After updating, the version cache wasn't cleared, so old update notifications persisted

## Changes
1. **Proper semantic version comparison**:
   - Added `compareVersions()` function that properly handles semantic versioning
   - Correctly handles `dev` versions (treats them as older than any release)
   - Supports v-prefixed versions (v1.0.0 vs 1.0.0)

2. **Cache management**:
   - Added `ClearCache()` function to remove version cache
   - Update command now clears cache after successful update
   - Prevents persistent update notifications

3. **Enhanced logic**:
   - Dev versions no longer trigger update notifications incorrectly
   - Version comparison now follows semantic versioning rules

## Test Results
Version comparison logic tested with these cases:
- ✅ dev < 0.0.15 (should update)
- ✅ 0.0.15 > 0.0.13 (should NOT update) 
- ✅ 0.0.13 < 0.0.15 (should update)
- ✅ 0.0.15 == 0.0.15 (should NOT update)

## Test plan
- [x] Verify version comparison logic works correctly
- [x] Test that dev versions don't show incorrect update notifications
- [x] Ensure cache is cleared after successful updates
- [x] Code builds and passes linting

Closes #5

🤖 Generated with [Claude Code](https://claude.ai/code)