### PR TITLE
fix: correct "newline word" in setup command

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -89,7 +89,7 @@ var setupCmd = &cobra.Command{
 		}
 
 		// Add to shell config
-		hookLine := fmt.Sprintf("\\n# rrk shell integration\\nsource %s\\n", hookFile)
+		hookLine := fmt.Sprintf("\n# rrk shell integration\nsource %s\n", hookFile)
 
 		file, err := os.OpenFile(shellConfigFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {


### PR DESCRIPTION
`rrk setup `コマンドにおいて履歴の取得が始まらない．

 setup.goの問題のある箇所
`hookLine := fmt.Sprintf("\\n# rrk shell integration\\nsource %s\\n", hookFile)`

上記setup.goにより.zshrcに記載された行
`export PATH="$PATH:/Users/noguchiair/.local/bin"\n# rrk shell integration\nsource /Users/noguchiair/rrk/hook.sh\n`


修正案
`hookLine := fmt.Sprintf("\n# rrk shell integration\nsource %s\n", hookFile)`
